### PR TITLE
fix(db): correct tracing span name for WriteLastSync


### DIFF
--- a/internal/db/lastSync.go
+++ b/internal/db/lastSync.go
@@ -39,7 +39,7 @@ func (db *DB) LastSync(ctx context.Context) LastSync {
 
 // WriteLastSync updates the last sync time in the database.
 func (db *DB) WriteLastSync(ctx context.Context, timestamp time.Time) error {
-	ctx, span := helpers.StartSpanOnTracerFromContext(ctx, "db.LastSync")
+	ctx, span := helpers.StartSpanOnTracerFromContext(ctx, "db.WriteLastSync")
 	defer span.End()
 
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)


### PR DESCRIPTION
### **User description**
## Summary
- correct tracing span for `WriteLastSync`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68439b139728832fa0159d97ef735cac


___

### **PR Type**
Bug fix


___

### **Description**
- Fix tracing span name in WriteLastSync


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lastSync.go</strong><dd><code>Update tracing span name in WriteLastSync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/db/lastSync.go

- Changed span name from "db.LastSync" to "db.WriteLastSync"


</details>


  </td>
  <td><a href="https://github.com/ADO-Asana-Sync/sync-engine/pull/144/files#diff-84bcd60f1c5a5de5bf9fe597bd784c5586b2c91f0459ab7ac38ac3846b0ff34c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>