### PR TITLE
fix(asana): use HTML notes when creating/updating tasks


### DIFF
--- a/internal/asana/asana.go
+++ b/internal/asana/asana.go
@@ -17,10 +17,11 @@ type AsanaInterface interface {
 	ProjectGIDByName(ctx context.Context, workspaceName, projectName string) (string, error)
 	ListProjectTasks(ctx context.Context, projectGID string) ([]Task, error)
 	// CreateTask creates a task in the given project. The notes parameter
-	// should contain HTML content which will be stored as the task description.
+	// should contain HTML wrapped in a <body> element which will be stored as
+	// the task description.
 	CreateTask(ctx context.Context, projectGID, name, notes string) (Task, error)
 	// UpdateTask updates an existing task. The notes parameter should
-	// contain HTML content for the description.
+	// contain HTML wrapped in a <body> element for the description.
 	UpdateTask(ctx context.Context, taskGID, name, notes string) error
 }
 

--- a/internal/asana/asana.go
+++ b/internal/asana/asana.go
@@ -16,7 +16,11 @@ type AsanaInterface interface {
 	ListWorkspaces(ctx context.Context) ([]Workspace, error)
 	ProjectGIDByName(ctx context.Context, workspaceName, projectName string) (string, error)
 	ListProjectTasks(ctx context.Context, projectGID string) ([]Task, error)
+	// CreateTask creates a task in the given project. The notes parameter
+	// should contain HTML content which will be stored as the task description.
 	CreateTask(ctx context.Context, projectGID, name, notes string) (Task, error)
+	// UpdateTask updates an existing task. The notes parameter should
+	// contain HTML content for the description.
 	UpdateTask(ctx context.Context, taskGID, name, notes string) error
 }
 

--- a/internal/asana/task.go
+++ b/internal/asana/task.go
@@ -45,6 +45,7 @@ func (a *Asana) ListProjectTasks(ctx context.Context, projectGID string) ([]Task
 	return result, nil
 }
 
+// CreateTask creates a new task in the given project using HTML notes for the description.
 func (a *Asana) CreateTask(ctx context.Context, projectGID, name, notes string) (Task, error) {
 	ctx, span := helpers.StartSpanOnTracerFromContext(ctx, "asana.CreateTask")
 	defer span.End()
@@ -54,9 +55,9 @@ func (a *Asana) CreateTask(ctx context.Context, projectGID, name, notes string) 
 	defer cancel()
 
 	fields := map[string]string{
-		"projects": projectGID,
-		"name":     name,
-		"notes":    notes,
+		"projects":   projectGID,
+		"name":       name,
+		"html_notes": notes,
 	}
 	t, err := client.CreateTask(ctx, fields, nil)
 	if err != nil {
@@ -65,6 +66,7 @@ func (a *Asana) CreateTask(ctx context.Context, projectGID, name, notes string) 
 	return Task{GID: t.GID, Name: t.Name}, nil
 }
 
+// UpdateTask updates an existing task using HTML notes for the description.
 func (a *Asana) UpdateTask(ctx context.Context, taskGID, name, notes string) error {
 	ctx, span := helpers.StartSpanOnTracerFromContext(ctx, "asana.UpdateTask")
 	defer span.End()
@@ -76,8 +78,8 @@ func (a *Asana) UpdateTask(ctx context.Context, taskGID, name, notes string) err
 
 	payload := map[string]map[string]string{
 		"data": {
-			"name":  name,
-			"notes": notes,
+			"name":       name,
+			"html_notes": notes,
 		},
 	}
 	b, err := json.Marshal(payload)

--- a/internal/asana/task.go
+++ b/internal/asana/task.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/ADO-Asana-Sync/sync-engine/internal/helpers"
 	asanaapi "github.com/range-labs/go-asana/asana"
@@ -54,6 +55,8 @@ func (a *Asana) CreateTask(ctx context.Context, projectGID, name, notes string) 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
+	notes = ensureHTMLBody(notes)
+
 	fields := map[string]string{
 		"projects":   projectGID,
 		"name":       name,
@@ -75,6 +78,8 @@ func (a *Asana) UpdateTask(ctx context.Context, taskGID, name, notes string) err
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
+
+	notes = ensureHTMLBody(notes)
 
 	payload := map[string]map[string]string{
 		"data": {
@@ -104,4 +109,13 @@ func (a *Asana) UpdateTask(ctx context.Context, taskGID, name, notes string) err
 		return fmt.Errorf("asana update failed: %s", string(body))
 	}
 	return nil
+}
+
+// ensureHTMLBody wraps the provided notes in a <body> element if one is not already present.
+func ensureHTMLBody(notes string) string {
+	lower := strings.ToLower(notes)
+	if strings.Contains(lower, "<body") {
+		return notes
+	}
+	return "<body>" + notes + "</body>"
 }

--- a/internal/asana/task_test.go
+++ b/internal/asana/task_test.go
@@ -142,7 +142,8 @@ func TestAsanaCreateTask(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resp := createTaskResponse(tt.task, tt.respErr)
-			client := testutil.NewTestClient(resp, nil)
+			var req *http.Request
+			client := testutil.NewTestClientWithRequest(resp, nil, &req)
 			a := &Asana{Client: client}
 			got, err := a.CreateTask(context.Background(), "42", tt.task.Name, "notes")
 			if tt.wantErr {
@@ -152,6 +153,12 @@ func TestAsanaCreateTask(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
+			require.NotNil(t, req)
+			require.Equal(t, http.MethodPost, req.Method)
+			require.NoError(t, req.ParseForm())
+			require.Equal(t, "42", req.Form.Get("projects"))
+			require.Equal(t, tt.task.Name, req.Form.Get("name"))
+			require.Equal(t, "notes", req.Form.Get("html_notes"))
 		})
 	}
 }
@@ -189,14 +196,18 @@ func TestAsanaUpdateTask(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := testutil.NewTestClient(tt.resp, tt.respErr)
+			var req *http.Request
+			client := testutil.NewTestClientWithRequest(tt.resp, tt.respErr, &req)
 			a := &Asana{Client: client}
 			err := a.UpdateTask(context.Background(), "1", "name", "notes")
 			if tt.wantErr {
 				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
+				return
 			}
+			require.NoError(t, err)
+			require.NotNil(t, req)
+			body, _ := io.ReadAll(req.Body)
+			require.Contains(t, string(body), "\"html_notes\":\"notes\"")
 		})
 	}
 }

--- a/internal/asana/task_test.go
+++ b/internal/asana/task_test.go
@@ -158,7 +158,7 @@ func TestAsanaCreateTask(t *testing.T) {
 			require.NoError(t, req.ParseForm())
 			require.Equal(t, "42", req.Form.Get("projects"))
 			require.Equal(t, tt.task.Name, req.Form.Get("name"))
-			require.Equal(t, "notes", req.Form.Get("html_notes"))
+			require.Equal(t, "<body>notes</body>", req.Form.Get("html_notes"))
 		})
 	}
 }
@@ -207,7 +207,13 @@ func TestAsanaUpdateTask(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, req)
 			body, _ := io.ReadAll(req.Body)
-			require.Contains(t, string(body), "\"html_notes\":\"notes\"")
+			var payload struct {
+				Data struct {
+					HTML string `json:"html_notes"`
+				} `json:"data"`
+			}
+			require.NoError(t, json.Unmarshal(body, &payload))
+			require.Equal(t, "<body>notes</body>", payload.Data.HTML)
 		})
 	}
 }

--- a/internal/testutil/roundtrip.go
+++ b/internal/testutil/roundtrip.go
@@ -20,3 +20,16 @@ func NewTestClient(resp *http.Response, err error) *http.Client {
 		}),
 	}
 }
+
+// NewTestClientWithRequest behaves like NewTestClient but also returns the
+// request received via the reqOut pointer for inspection in tests.
+func NewTestClientWithRequest(resp *http.Response, err error, reqOut **http.Request) *http.Client {
+	return &http.Client{
+		Transport: RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if reqOut != nil {
+				*reqOut = req
+			}
+			return resp, err
+		}),
+	}
+}


### PR DESCRIPTION
### **User description**
## Summary
- send task description using `html_notes` when creating/updating tasks
- add helper to capture HTTP requests during tests
- verify `html_notes` usage in task tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6844fdd9b810832f886282f1178aaea0


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Use `html_notes` for Asana task descriptions

- Update CreateTask/UpdateTask to send HTML notes

- Add test client helper to capture requests

- Enhance tests to assert HTML notes usage


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>asana.go</strong><dd><code>Add HTML notes method documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/asana/asana.go

<li>Document HTML notes support in interface<br> <li> Add comments for CreateTask and UpdateTask


</details>


  </td>
  <td><a href="https://github.com/ADO-Asana-Sync/sync-engine/pull/151/files#diff-e9b6eb1bab57cfbbd79d26f7084a1b24574fd8463666b6ea3537e42422f42d51">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>task.go</strong><dd><code>Switch payload keys to html_notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/asana/task.go

<li>Replace <code>notes</code> with <code>html_notes</code> in payload<br> <li> Update CreateTask and UpdateTask implementations<br> <li> Add comments about HTML description usage


</details>


  </td>
  <td><a href="https://github.com/ADO-Asana-Sync/sync-engine/pull/151/files#diff-5a25250fe406ddac8ec05447cfd165e0f48cf1e04cc94b5f6363ab8335179df4">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>task_test.go</strong><dd><code>Test html_notes in Create/UpdateTask</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/asana/task_test.go

<li>Use NewTestClientWithRequest to capture requests<br> <li> Assert HTTP method and form/body contains html_notes<br> <li> Retain existing error and response checks


</details>


  </td>
  <td><a href="https://github.com/ADO-Asana-Sync/sync-engine/pull/151/files#diff-4dba07e95d0003cfd8130c8fa8f901de469d3653c15426457c0b8e8b4f5dde0b">+15/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>roundtrip.go</strong><dd><code>Add request-capturing test client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/testutil/roundtrip.go

<li>Add NewTestClientWithRequest to capture HTTP requests<br> <li> Return request via pointer for test inspection


</details>


  </td>
  <td><a href="https://github.com/ADO-Asana-Sync/sync-engine/pull/151/files#diff-4ba885b9de6dc575738abe7f2c2b4af4dc6801ed6424aa53805ae1c0367b266a">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>