### PR TITLE
feat(db): enforce unique ADO-to-Asana project mappings


### DIFF
--- a/cmd/sync/controller_test.go
+++ b/cmd/sync/controller_test.go
@@ -18,6 +18,7 @@ type mockDB struct{ wrote bool }
 
 func (m *mockDB) Connect(ctx context.Context, uri string) error                  { return nil }
 func (m *mockDB) Disconnect(ctx context.Context) error                           { return nil }
+func (m *mockDB) EnsureIndexes(ctx context.Context) error                        { return nil }
 func (m *mockDB) Projects(ctx context.Context) ([]db.Project, error)             { return nil, nil }
 func (m *mockDB) AddProject(ctx context.Context, project db.Project) error       { return nil }
 func (m *mockDB) RemoveProject(ctx context.Context, id primitive.ObjectID) error { return nil }

--- a/cmd/sync/main.go
+++ b/cmd/sync/main.go
@@ -148,6 +148,12 @@ func (app *App) setup(ctx context.Context) error {
 		return fmt.Errorf("error connecting to the DB: %v", err)
 	}
 
+	if err := app.DB.EnsureIndexes(ctx); err != nil {
+		span.RecordError(err, trace.WithStackTrace(true))
+		span.SetStatus(codes.Error, err.Error())
+		return fmt.Errorf("error ensuring DB indexes: %v", err)
+	}
+
 	// Azure DevOps setup.
 	log.Info("connecting to Azure DevOps")
 	app.Azure = azure.NewAzure()

--- a/cmd/web-ui/main.go
+++ b/cmd/web-ui/main.go
@@ -103,6 +103,12 @@ func (app *App) setup(ctx context.Context) error {
 		return fmt.Errorf("error connecting to the DB: %v", err)
 	}
 
+	if err := app.DB.EnsureIndexes(ctx); err != nil {
+		span.RecordError(err, trace.WithStackTrace(true))
+		span.SetStatus(codes.Error, err.Error())
+		return fmt.Errorf("error ensuring DB indexes: %v", err)
+	}
+
 	// Azure DevOps setup.
 	log.Info("connecting to Azure DevOps")
 	app.Azure = azure.NewAzure()

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -113,7 +113,7 @@ func (db *DB) EnsureIndexes(ctx context.Context) error {
 
 	coll := db.Client.Database(DatabaseName).Collection(ProjectsCollection)
 	_, err := coll.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys:    bson.D{{Key: "ado_project_name", Value: 1}},
+		Keys:    bson.D{bson.E{Key: "ado_project_name", Value: 1}},
 		Options: options.Index().SetUnique(true),
 	})
 	if err != nil {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -2,12 +2,14 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strconv"
 	"time"
 
 	"github.com/ADO-Asana-Sync/sync-engine/internal/helpers"
 	"github.com/sirupsen/logrus"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -32,6 +34,7 @@ var (
 type DBInterface interface {
 	Connect(ctx context.Context, uri string) error
 	Disconnect(ctx context.Context) error
+	EnsureIndexes(ctx context.Context) error
 	Projects(ctx context.Context) ([]Project, error)
 	AddProject(ctx context.Context, project Project) error
 	RemoveProject(ctx context.Context, id primitive.ObjectID) error
@@ -98,4 +101,26 @@ func (db *DB) Disconnect(ctx context.Context) error {
 
 func clientOptions(uri string) *options.ClientOptions {
 	return options.Client().ApplyURI(uri).SetMaxPoolSize(getMaxPoolSize()).SetRetryReads(true).SetRetryWrites(true)
+}
+
+// EnsureIndexes creates required MongoDB indexes.
+func (db *DB) EnsureIndexes(ctx context.Context) error {
+	ctx, span := helpers.StartSpanOnTracerFromContext(ctx, "db.EnsureIndexes")
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(ctx, Timeout)
+	defer cancel()
+
+	coll := db.Client.Database(DatabaseName).Collection(ProjectsCollection)
+	_, err := coll.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys:    bson.D{{Key: "ado_project_name", Value: 1}},
+		Options: options.Index().SetUnique(true),
+	})
+	if err != nil {
+		span.RecordError(err, trace.WithStackTrace(true))
+		span.SetStatus(codes.Error, err.Error())
+		return fmt.Errorf("error creating project index: %v", err)
+	}
+
+	return nil
 }

--- a/internal/db/project.go
+++ b/internal/db/project.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -74,7 +75,7 @@ func (db *DB) AddProject(ctx context.Context, project Project) error {
 		if existing.AsanaProjectName == project.AsanaProjectName && existing.AsanaWorkspaceName == project.AsanaWorkspaceName {
 			err = fmt.Errorf("project already exists")
 		} else {
-			err = fmt.Errorf(errADOProjectAlreadyMapped)
+			err = errors.New(errADOProjectAlreadyMapped)
 		}
 		span.RecordError(err)
 		return err
@@ -84,7 +85,7 @@ func (db *DB) AddProject(ctx context.Context, project Project) error {
 	_, err = collection.InsertOne(dbCtx, project)
 	if err != nil {
 		if mongo.IsDuplicateKeyError(err) {
-			err = fmt.Errorf(errADOProjectAlreadyMapped)
+			err = errors.New(errADOProjectAlreadyMapped)
 		} else {
 			err = fmt.Errorf("error inserting project: %v", err)
 		}
@@ -147,7 +148,7 @@ func (db *DB) UpdateProject(ctx context.Context, project Project) error {
 		return err
 	}
 	if err == nil {
-		err = fmt.Errorf(errADOProjectAlreadyMapped)
+		err = errors.New(errADOProjectAlreadyMapped)
 		span.RecordError(err)
 		return err
 	}

--- a/internal/db/project.go
+++ b/internal/db/project.go
@@ -17,6 +17,8 @@ var (
 	ProjectsCollection = "projects"
 )
 
+const errADOProjectAlreadyMapped = "ADO project already mapped to a different Asana project"
+
 // Project represents a project with its corresponding names in ADO and Asana.
 type Project struct {
 	ID                 primitive.ObjectID `json:"id" bson:"_id"`
@@ -72,7 +74,7 @@ func (db *DB) AddProject(ctx context.Context, project Project) error {
 		if existing.AsanaProjectName == project.AsanaProjectName && existing.AsanaWorkspaceName == project.AsanaWorkspaceName {
 			err = fmt.Errorf("project already exists")
 		} else {
-			err = fmt.Errorf("ADO project already mapped to a different Asana project")
+			err = fmt.Errorf(errADOProjectAlreadyMapped)
 		}
 		span.RecordError(err)
 		return err
@@ -82,7 +84,7 @@ func (db *DB) AddProject(ctx context.Context, project Project) error {
 	_, err = collection.InsertOne(dbCtx, project)
 	if err != nil {
 		if mongo.IsDuplicateKeyError(err) {
-			err = fmt.Errorf("ADO project already mapped to a different Asana project")
+			err = fmt.Errorf(errADOProjectAlreadyMapped)
 		} else {
 			err = fmt.Errorf("error inserting project: %v", err)
 		}
@@ -145,7 +147,7 @@ func (db *DB) UpdateProject(ctx context.Context, project Project) error {
 		return err
 	}
 	if err == nil {
-		err = fmt.Errorf("ADO project already mapped to a different Asana project")
+		err = fmt.Errorf(errADOProjectAlreadyMapped)
 		span.RecordError(err)
 		return err
 	}

--- a/internal/db/project.go
+++ b/internal/db/project.go
@@ -81,7 +81,11 @@ func (db *DB) AddProject(ctx context.Context, project Project) error {
 	// Insert the new project with a unique ID.
 	_, err = collection.InsertOne(dbCtx, project)
 	if err != nil {
-		err = fmt.Errorf("error inserting project: %v", err)
+		if mongo.IsDuplicateKeyError(err) {
+			err = fmt.Errorf("ADO project already mapped to a different Asana project")
+		} else {
+			err = fmt.Errorf("error inserting project: %v", err)
+		}
 		span.RecordError(err)
 		return err
 	}


### PR DESCRIPTION
### **User description**
## Summary
- ensure only one mapping per ADO project when adding projects
- check for existing mappings when updating projects

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6860ca245508832fbde5e5506e67e823


___

### **PR Type**
Enhancement


___

### **Description**
- Add `FindOne` check for existing ADO mapping

- Differentiate conflict errors in AddProject

- Prevent duplicate mapping in UpdateProject

- Replace `CountDocuments` with error-based logic


___

### **Changes diagram**

```mermaid
flowchart LR
  A["AddProject"] --> B["FindOne by ADO project"]
  B -- "exists" --> C["Return conflict error"]
  B -- "not exists" --> D["Insert new project"]
  E["UpdateProject"] --> F["FindOne by ADO project != ID"]
  F -- "exists" --> G["Return mapping conflict"]
  F -- "not exists" --> H["Update project record"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>project.go</strong><dd><code>Enforce unique ADO-to-Asana mapping checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/db/project.go

<li>Added <code>FindOne</code> check for existing ADO project mappings<br> <li> Differentiated errors for existing vs. conflicting mappings<br> <li> Removed <code>CountDocuments</code> in AddProject<br> <li> Added duplicate mapping guard in UpdateProject


</details>


  </td>
  <td><a href="https://github.com/ADO-Asana-Sync/sync-engine/pull/188/files#diff-46df9573881f5066acf8adcd29f3da178bc8586122341fb22ced670e95cd71f3">+32/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>